### PR TITLE
Salvage buff

### DIFF
--- a/code/modules/vehicles/rubbish.dm
+++ b/code/modules/vehicles/rubbish.dm
@@ -63,7 +63,7 @@
 	for(var/i2 in 1 to (2+modifier))
 		new /obj/item/salvage/low(usr_turf)
 	for(var/i3 in 1 to (1+modifier)) //this is just less lines for the same thing
-		if(prob(3))
+		if(prob(10))
 			new /obj/item/salvage/high(usr_turf)
 	uses_left--
 	inuse = FALSE //putting this after the -- because the first check prevents cheesing


### PR DESCRIPTION
Finding salvage for making guns is pain, this fixes it so that people don't have to do the funny glitch (which was fixed) if they want to make more than one gun, without spending the whole round doing so. Does NOT re-add tool salvage to cars, before people start whining about lag. 

Exact changes, triples the current drop rate of advanced pre-war salvage. Since the exploit with the crafting benches was patched out, this should be fine.